### PR TITLE
Added option to only save relative paths

### DIFF
--- a/aidesign/Data/Data_core.py
+++ b/aidesign/Data/Data_core.py
@@ -94,7 +94,7 @@ class Data(object):
         :param filename: str, filename of file to be loaded
         :param data_name: str, name of class variable data will be loaded to
         """
-        filename = self._rel_to_abs(filename)
+        filename = self._rel_to_abs(filename).replace("\\","/").replace("/",path.sep)
         ext = self._get_ext(filename)
         getattr(self,"_import_{0}".format(ext))(filename,data_name)
 

--- a/aidesign/Data/xml_handler.py
+++ b/aidesign/Data/xml_handler.py
@@ -433,7 +433,20 @@ class XML_handler(object):
     def append_input_data(self,
                             data_name: str,
                             data_dir: str,
-                            xml_parent: ET.Element or str = "Initialiser"):
+                            xml_parent: ET.Element or str = "Initialiser",
+                            save_dir_as_relative: bool = True):
+        """Appened path to input datafile. Replaces windows backslash
+
+        :param plugin_type: string type of plugin to be loaded into module
+        :param plugin_options: dict where keys & values are options & values
+        :param xml_parent: dict OR str. 
+                            If string given, parent elem is found via search,
+                            Otherwise, plugin appeneded directly
+        :param save_dir_as_relative: bool. If True [default], attempts to 
+                            replace the library base path in the absolute
+                            filename with "./" to make it relative to library
+                            path. Recommended.
+        """
         if isinstance(xml_parent, str):
             xml_parent = self._get_element_from_name(xml_parent)
 
@@ -443,6 +456,9 @@ class XML_handler(object):
             input_data_elem = ET.SubElement(xml_parent, "inputdata")
             
         plugin_elem = ET.SubElement(input_data_elem, data_name)
+        if save_dir_as_relative:
+            data_dir = data_dir.replace(self.lib_base_path,"./")
+        data_dir = data_dir.replace("\\","/")
         plugin_elem.set('file', data_dir)
 
     def append_plugin_to_module(self,


### PR DESCRIPTION
# Purpose
Closes #34 

When data directories are added to `input_data` during xml building, they were previously saved as absolute paths ony, which makes sharing example files difficult. 

This adds the option (activated by default) to save data paths as relative paths within the library if they are located there.

## In brief
 - Added an option to  `append_input_data` in `xml_handler.py` to save only relative paths (active by default)
 - In `Data_core`, improved robustness by replacing all fileseps with OS-specific fileseps at runtime to improve cross-OS compatibility

## Relative path saving

In `xml_handler.py`:

```python
if save_dir_as_relative:
    data_dir = data_dir.replace(self.lib_base_path,"./")
data_dir = data_dir.replace("\\","/")
```

If `save_dir_as_relative` is True, `data_dir.replace` tries to find the basename of the library in the dir name and replaces it with `./`, which will be then re-substituted with the library basename as needed later. 

This improves cross-OS compatibility and config file sharing