### PR TITLE
Added Test Action

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,7 +1,6 @@
 name: Test VAI-Lab
 
-# on: [pull_request]
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: CI Tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Test VAI-Lab
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash
@@ -23,11 +23,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
+          sudo apt install xvfb -y
+          Xvfb :0
+          export DISPLAY=:0
       - name: Test with pytest
         run: |
           pip install pytest
           pip install pytest-cov
-          pytest tests --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
+          pytest --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
 # #      - name: Typecheck with mypy
 # #        run: |
 # #          source $VENV

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,15 +23,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
-      - name: Install virtual display
-        uses: GabrielBB/xvfb-action@v1.6
+      - name: Test with pytest
+        # uses: GabrielBB/xvfb-action@v1.6
+        uses: hankolsen/xvfb-action@dcb076c1c3802845f73bb6fe14a009d8d3377255
         with:
           run: |
             pip install pytest
             pip install pytest-cov
             pytest --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
-      # - name: Test with pytest
-# #      - name: Typecheck with mypy
-# #        run: |
-# #          source $VENV
-# #          make typecheck
+
+
+        # Note: hankolsen/xvfb-action@dcb076c1c3802845f73bb6fe14a009d8d3377255 is a 
+        # PR waiting to be merged to GabrielBB/xvfb-action@v1.6 to update xvfb-action
+        # to node.js 16. After the merge, switch back to GabrielBB/xvfb-action@v1.6

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
-name: Test VAI-Lab
+name: CI Tests
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,35 @@
+name: Test VAI-Lab
+
+# on: [pull_request]
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest tests --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
+# #      - name: Typecheck with mypy
+# #        run: |
+# #          source $VENV
+# #          make typecheck

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,14 +23,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .
-          sudo apt install xvfb -y
-          Xvfb :0
-          export DISPLAY=:0
-      - name: Test with pytest
-        run: |
-          pip install pytest
-          pip install pytest-cov
-          pytest --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
+      - name: Install virtual display
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: |
+            pip install pytest
+            pip install pytest-cov
+            pytest --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
+      # - name: Test with pytest
 # #      - name: Typecheck with mypy
 # #        run: |
 # #          source $VENV

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Test VAI-Lab
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,7 @@ jobs:
           run: |
             pip install pytest
             pip install pytest-cov
-            pytest --cov=.src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
+            pytest --cov=./src/vai_lab -v --cov-report=xml:./coverage.xml --cov-report term-missing
 
 
         # Note: hankolsen/xvfb-action@dcb076c1c3802845f73bb6fe14a009d8d3377255 is a 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+[![Test VAI-Lab](https://github.com/AaltoPML/VAI-Lab/actions/workflows/pythonpackage.yml/badge.svg)](https://github.com/AaltoPML/VAI-Lab/actions/workflows/pythonpackage.yml) [![PyPI Version](https://img.shields.io/pypi/v/vai-lab?color=blue)](https://pypi.org/project/vai-lab/) [![Python Versions](https://img.shields.io/pypi/pyversions/vai-lab?color=blue)](https://pypi.org/project/vai-lab/) [![Wheel](https://img.shields.io/pypi/wheel/vai-lab)](https://pypi.org/project/vai-lab/) [![License](https://img.shields.io/pypi/l/vai-lab)](https://pypi.org/project/vai-lab/)
+
+
 # Virtual Artificially Intelligent Laboratories (VAI-Lab)
 
 ![AIDBANNER](./imgs/VAIL_banner_image.png)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ authors = [
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: MIT License",
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11'
 ]
 requires-python = ">=3.8"
 version = "0.0.dev1"

--- a/src/vai_lab/Core/vai_lab_core.py
+++ b/src/vai_lab/Core/vai_lab_core.py
@@ -16,10 +16,13 @@ class Core:
         self.data = Data()
         self.loop_level: int = 0
         self.setup_complete: bool = False
+        
         self.status_logger:Dict = {}
+        self._debug = False
 
     def _launch(self):
         gui_app = GUI()
+        gui_app._debug = self._debug
         gui_app.set_avail_plugins(self._avail_plugins)
         gui_app.set_gui_as_startpage()
         gui_output = gui_app.launch()

--- a/src/vai_lab/GUI/GUI_core.py
+++ b/src/vai_lab/GUI/GUI_core.py
@@ -25,6 +25,7 @@ class GUI(tk.Tk):
         self._desired_ui_types = []
         self._top_ui_layer = None
         self._module_config = None
+        self._debug = False
         self.closed = False
         self.startpage = False
         self.output = {}
@@ -153,7 +154,10 @@ class GUI(tk.Tk):
 
         self._show_frame(self._top_ui_layer)
         self.protocol("WM_DELETE_WINDOW", self._on_closing)
-        self.mainloop()
+        if not self._debug:
+            self.mainloop()
+        else:
+            self.closed = True
         return self.output
 
     def get_result(self):

--- a/src/vai_lab/tests/test_launch.py
+++ b/src/vai_lab/tests/test_launch.py
@@ -7,4 +7,5 @@ core = ai.Core()
 #     "xml_files",
 #     'pybullet_env_example.xml'))
     
+core._debug = True
 core.run()

--- a/src/vai_lab/tests/test_launch.py
+++ b/src/vai_lab/tests/test_launch.py
@@ -1,11 +1,9 @@
 import vai_lab as ai
 
-core = ai.Core()
-
-# core.load_config_file(
-#     ("./examples",
-#     "xml_files",
-#     'pybullet_env_example.xml'))
-    
-core._debug = True
-core.run()
+def test_launch():
+    """
+    Test launching GUI
+    """
+    core = ai.Core()    
+    core._debug = True
+    core.run()


### PR DESCRIPTION
# Purpose 

Add workflow for testing at PR

## GH Actions

- Added `.github/workflows/pythonpackage.yml` to define tests and deps
- Workflow triggers on pull_request
- Tests windows, max, ubuntu with python 3.8, 3.9, 3.10, 3.11 (3.7 fails)
- Using `xvfb` to create a virtual display to allow testing of TKInter for GUI
  - Uses [GabrielBB/xvfb-action@v1.6](https://github.com/GabrielBB/xvfb-action) to install and manage `xvfb`
  - This repo has an open PR to update node.js to v16, so currently using that version: `hankolsen/xvfb-action@dcb076c1c3802845f73bb6fe14a009d8d3377255` as the github action - update this back to `GabrielBB/xvfb-action@v1.6` when the PR has been merged

## README.md shields

 - Went a little overboard to add shields to the README
 - Currently, the python version shield does not work, is waiting for an update to PyPI, which I can do soon