### PR TITLE
fixed for loop logic and error handling in core

### DIFF
--- a/src/vai_lab/Core/vai_lab_core.py
+++ b/src/vai_lab/Core/vai_lab_core.py
@@ -70,15 +70,16 @@ class Core:
         self.data = mod.get_result()
 
     def _execute_loop(self, specs):
-        try:
+        if  hasattr(self,"_execute_{}_loop".format(specs["type"])):
             print("\t"*self.loop_level
+                        + "Starting "
                         + specs["type"]
                         + " loop: \"{}\"".format(specs["name"])
-                        + " starting...")
+                        + " ...")
             self.loop_level += 1
             getattr(self, "_execute_{}_loop".format(specs["type"]))(specs)
             self.loop_level -= 1
-        except KeyError:
+        else:
             print("\nError: Invalid Loop Type.")
             print("Loop \"{0}\" with type \"{1}\" not recognised".format(
                 specs["name"], specs["type"]))


### PR DESCRIPTION
Fix for core loops. 

Previous behaviour: loops would throw a keyerror if the nested module was not recognised, leading to incorrect error catching

Fixed behaviour: loops and modules now throw informative and appropriate errors